### PR TITLE
Update to postcss-values-parser 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to PostCSS Place Properties
 
+## [Unreleased]
+
+- Updated: PostCSS Values Parser to version 3 (`^3.0.5`)
+- Updated: Minimal NodeJS version `>=6.14.4`
+- Updated: Production dependencies (`postcss ^7.0.18`)
+
 ### 4.0.1 (September 18, 2018)
 
 - Updated: PostCSS Values Parser 2 (patch for this project)

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "test:tape": "postcss-tape"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=6.14.4"
   },
   "dependencies": {
-    "postcss": "^7.0.2",
-    "postcss-values-parser": "^2.0.0"
+    "postcss": "^7.0.18",
+    "postcss-values-parser": "^3.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",


### PR DESCRIPTION
- Update to postcss-values-parser v3 (https://github.com/shellscape/postcss-values-parser)
- Update production dependencies
- Update minimal NodeJS version based on production dependencies